### PR TITLE
Fix Modifiers & Clean up Whitespace

### DIFF
--- a/config/IguanaTinkerTweaks/main.cfg
+++ b/config/IguanaTinkerTweaks/main.cfg
@@ -186,12 +186,12 @@ randombonuses {
 toolleveling {
     # Adds a random bonus on these levelups if 'RandomBonuses' is enabled
     I:BonusesAtLevels <
-	1
-	2
-	3
-	4
-	5
-	6
+		1
+		2
+		3
+		4
+		5
+		6
      >
 
     # Each modifier is equally likely on levelup. Disables useful bonuses. [default: false]
@@ -202,10 +202,9 @@ toolleveling {
 
     # Adds an extra modifier on these levelups if 'ExtraModifiers' is enabled
     I:ModifiersAtLevels <
-     >
-     3
-     6
-     
+        3
+        6
+    >     
 
     # Gives a random bonus every level, if false and levelling is on modifiers are given at levels 2 and 4 (requires 'toolLeveling=true') [default: true]
     B:RandomBonuses=true


### PR DESCRIPTION
ModifiersAtLevels was closed before the 3 and 6 levels.
Cleaned up some whitespace on BonusesAtLevels and ModifiersAtLevels to
make it easier to read.
