### PR TITLE
Minetweaker Changes

### DIFF
--- a/scripts/duplicates.zs
+++ b/scripts/duplicates.zs
@@ -1,63 +1,69 @@
-//Capture Wand
-//disabled recipes.remove(<ExtraUtilities:golden_lasso>);
-recipes.remove(<EnderIO:itemSoulVessel>);
+// Capture Wand
+// disabled recipes.remove(<ExtraUtilities:golden_lasso>);
+//recipes.remove(<EnderIO:itemSoulVessel>);
 
 
-//Fans, Fertilizer, Etc
+// Fans, Fertilizer, Etc
 recipes.remove(<EnderIO:blockFarmStation>);
 
-//Mob Harvester
+// Mob Harvester
 recipes.remove(<ExtraUtilities:spike_base>);
 recipes.remove(<ExtraUtilities:spike_base_diamond>);
 recipes.remove(<ExtraUtilities:spike_base_gold>);
 recipes.remove(<ExtraUtilities:spike_base_wood>);
 
-//Spawner Controller
+// Spawner Controller
 recipes.remove(<EnderIO:blockPoweredSpawner>);
 
-//Orange Pendant
+// Orange Pendant
 recipes.remove(<Botania:superLavaPendant>);
 
-//Pendants
+// Pendants
 recipes.remove(<Botania:bloodPendant>);
 
-//Sprinkler
+// Sprinkler
 //recipes.remove(<OpenBlocks:sprinkler>);
 //recipes.remove(<AgriCraft:sprinkler>);
 
-//AgriCraft
+// AgriCraft
 recipes.remove(<IC2:blockCrop>);
 
-//Item Vac
+// Item Vac
 recipes.remove(<EnderIO:blockVacuumChest>);
 
-//Magnetism Ability
+// Magnetism Ability
 recipes.remove(<MagicBees:magnet>);
 recipes.remove(<EnderIO:itemMagnet:16>);
 recipes.remove(<Botania:magnetRingGreater>);
 recipes.remove(<AWWayofTime:sigilOfMagnetism>);
 
+// Extra Utilities World Interaction Upgrade
 //recipes.remove(<ExtraUtilities:nodeUpgrade:2>);
 
-//Baitbox
+// Baitbox
 recipes.remove(<EnderIO:blockAttractor>);
 
-//CC spawning lamp
+// CC spawning lamp
 recipes.remove(<ExtraUtilities:chandelier>);
-recipes.remove(<ExtraUtilities:magnumTorch>); //may want custom recipe here
+recipes.remove(<ExtraUtilities:magnumTorch>); //may want custom recipe here -- use the spawning lamp?
 recipes.remove(<EnderIO:blockSpawnGuard>);
 
-//Obsidian Factory
-mods.tconstruct.Smeltery.removeAlloy(<liquid:obsidian.molten>);
-recipes.remove(<minecraft:obsidian>);
+// Obsidian Factory
+//mods.tconstruct.Smeltery.removeAlloy(<liquid:obsidian.molten>);
+//recipes.remove(<minecraft:obsidian>);
 
-//Crystal Tanks
+// Make the 1k ME Fluid Storage Component more expensive
+// Primarily switches out the gold/logic processor for a 4k AE2 Storage Component, and lapis becomes blue dye
 recipes.remove(<extracells:storage.component:4>);
 recipes.addShaped(<extracells:storage.component:4>, [[<minecraft:dye:4>, <appliedenergistics2:item.ItemMultiMaterial:1>, <minecraft:dye:4>], [<appliedenergistics2:item.ItemMultiMaterial:1>, <appliedenergistics2:item.ItemMultiMaterial:36>, <appliedenergistics2:item.ItemMultiMaterial:1>], [<minecraft:dye:4>, <appliedenergistics2:item.ItemMultiMaterial:1>, <minecraft:dye:4>]]);
 
-recipes.remove(<extracells:storage.component:11>);
-recipes.addShaped(<extracells:storage.component:11>, [[<minecraft:dye:11>, <appliedenergistics2:item.ItemMultiMaterial:1>, <minecraft:dye:11>], [<appliedenergistics2:item.ItemMultiMaterial:1>, <appliedenergistics2:item.ItemMultiMaterial:36>, <appliedenergistics2:item.ItemMultiMaterial:1>], [<minecraft:dye:11>, <appliedenergistics2:item.ItemMultiMaterial:1>, <minecraft:dye:11>]]);
+// Make the 1k ME Gas Storage Component more expensive
+// Primarily switches out the gold/logic processor for a 4k AE2 Storage Component, and lapis becomes blue dye
+// Commented out because the Gas Storage Components are only enabled if Mekanism is found, and we're not using it.
+//recipes.remove(<extracells:storage.component:11>);
+//recipes.addShaped(<extracells:storage.component:11>, [[<minecraft:dye:11>, <appliedenergistics2:item.ItemMultiMaterial:1>, <minecraft:dye:11>], [<appliedenergistics2:item.ItemMultiMaterial:1>, <appliedenergistics2:item.ItemMultiMaterial:36>, <appliedenergistics2:item.ItemMultiMaterial:1>], [<minecraft:dye:11>, <appliedenergistics2:item.ItemMultiMaterial:1>, <minecraft:dye:11>]]);
 
+// Remove default extracells fluid and gas cell recipes
 recipes.remove(<extracells:storage.fluid>);
 recipes.remove(<extracells:storage.fluid:1>);
 recipes.remove(<extracells:storage.fluid:2>);
@@ -65,16 +71,31 @@ recipes.remove(<extracells:storage.fluid:3>);
 recipes.remove(<extracells:storage.fluid:4>);
 recipes.remove(<extracells:storage.fluid:5>);
 recipes.remove(<extracells:storage.fluid:6>);
-recipes.remove(<extracells:storage.gas>);
-recipes.remove(<extracells:storage.gas:1>);
-recipes.remove(<extracells:storage.gas:2>);
-recipes.remove(<extracells:storage.gas:3>);
-recipes.remove(<extracells:storage.gas:4>);
-recipes.remove(<extracells:storage.gas:5>);
-recipes.remove(<extracells:storage.gas:6>);
 
+// Gas recipes commented out because it depends on Mekanism, which we don't have.
+//recipes.remove(<extracells:storage.gas>);
+//recipes.remove(<extracells:storage.gas:1>);
+//recipes.remove(<extracells:storage.gas:2>);
+//recipes.remove(<extracells:storage.gas:3>);
+//recipes.remove(<extracells:storage.gas:4>);
+//recipes.remove(<extracells:storage.gas:5>);
+//recipes.remove(<extracells:storage.gas:6>);
+
+// We'll use this var to save a little bit of typing
+// It's the ChromatiCraft Crystal Tank ChromatiCraft
 var tank = <ChromatiCraft:chromaticraft_item_placer:17>;
 
+// Gating extracells fluid and gas casings behind the ChromatiCraft Crystal Tank Controller
+// Fluid casing -- swap out fluix dust for fluix blocks and a tank for the Crystal Tank Controller
+recipes.remove(<extracells:storage.casing:1>);
+recipes.addShaped(<extracells:storage.casing:1>, [[<appliedenergistics2:tile.BlockQuartzGlass>, <appliedenergistics2:tile.BlockFluix>, <appliedenergistics2:tile.BlockQuartzGlass>],[<appliedenergistics2:tile.BlockFluix>, null, <appliedenergistics2:tile.BlockFluix>],[<extracells:certustank>, tank, <extracells:certustank>]]);
+
+// Gas casing -- swap out fluix dust for fluix blocks and a tank for the Crystal Tank Controller
+// Again, these are commented out due to the lack of Mekanism
+//recipes.remove(<extracells:storage.casing:2>);
+//recipes.addShaped(<extracells:storage.casing:2>, [[<appliedenergistics2:tile.BlockQuartzGlass>, <appliedenergistics2:tile.BlockFluix>, <appliedenergistics2:tile.BlockQuartzGlass>],[<appliedenergistics2:tile.BlockFluix>, null, <appliedenergistics2:tile.BlockFluix>],[<ore:ingotGold>, tank, <ore:ingotGold>]]);
+
+// Gating all fluid storage cells behind the ChromatiCraft Crystal Tank Controller, and swap out fluix dust for fluix blocks
 recipes.addShaped(<extracells:storage.fluid>, [[<appliedenergistics2:tile.BlockQuartzGlass>, <appliedenergistics2:tile.BlockFluix>, <appliedenergistics2:tile.BlockQuartzGlass>],[<appliedenergistics2:tile.BlockFluix>, <extracells:storage.component:4>, <appliedenergistics2:tile.BlockFluix>],[<extracells:certustank>, tank, <extracells:certustank>]]);
 recipes.addShaped(<extracells:storage.fluid:1>, [[<appliedenergistics2:tile.BlockQuartzGlass>, <appliedenergistics2:tile.BlockFluix>, <appliedenergistics2:tile.BlockQuartzGlass>],[<appliedenergistics2:tile.BlockFluix>, <extracells:storage.component:5>, <appliedenergistics2:tile.BlockFluix>],[<extracells:certustank>, tank, <extracells:certustank>]]);
 recipes.addShaped(<extracells:storage.fluid:2>, [[<appliedenergistics2:tile.BlockQuartzGlass>, <appliedenergistics2:tile.BlockFluix>, <appliedenergistics2:tile.BlockQuartzGlass>],[<appliedenergistics2:tile.BlockFluix>, <extracells:storage.component:6>, <appliedenergistics2:tile.BlockFluix>],[<extracells:certustank>, tank, <extracells:certustank>]]);
@@ -83,18 +104,16 @@ recipes.addShaped(<extracells:storage.fluid:4>, [[<appliedenergistics2:tile.Bloc
 recipes.addShaped(<extracells:storage.fluid:5>, [[<appliedenergistics2:tile.BlockQuartzGlass>, <appliedenergistics2:tile.BlockFluix>, <appliedenergistics2:tile.BlockQuartzGlass>],[<appliedenergistics2:tile.BlockFluix>, <extracells:storage.component:9>, <appliedenergistics2:tile.BlockFluix>],[<extracells:certustank>, tank, <extracells:certustank>]]);
 recipes.addShaped(<extracells:storage.fluid:6>, [[<appliedenergistics2:tile.BlockQuartzGlass>, <appliedenergistics2:tile.BlockFluix>, <appliedenergistics2:tile.BlockQuartzGlass>],[<appliedenergistics2:tile.BlockFluix>, <extracells:storage.component:10>, <appliedenergistics2:tile.BlockFluix>],[<extracells:certustank>, tank, <extracells:certustank>]]);
 
-recipes.addShaped(<extracells:storage.gas>, [[<appliedenergistics2:tile.BlockQuartzGlass>, <appliedenergistics2:tile.BlockFluix>, <appliedenergistics2:tile.BlockQuartzGlass>],[<appliedenergistics2:tile.BlockFluix>, <extracells:storage.component:11>, <appliedenergistics2:tile.BlockFluix>],[<ore:ingotGold>, tank, <ore:ingotGold>]]);
-recipes.addShaped(<extracells:storage.gas:1>, [[<appliedenergistics2:tile.BlockQuartzGlass>, <appliedenergistics2:tile.BlockFluix>, <appliedenergistics2:tile.BlockQuartzGlass>],[<appliedenergistics2:tile.BlockFluix>, <extracells:storage.component:12>, <appliedenergistics2:tile.BlockFluix>],[<ore:ingotGold>, tank, <ore:ingotGold>]]);
-recipes.addShaped(<extracells:storage.gas:2>, [[<appliedenergistics2:tile.BlockQuartzGlass>, <appliedenergistics2:tile.BlockFluix>, <appliedenergistics2:tile.BlockQuartzGlass>],[<appliedenergistics2:tile.BlockFluix>, <extracells:storage.component:13>, <appliedenergistics2:tile.BlockFluix>],[<ore:ingotGold>, tank, <ore:ingotGold>]]);
-recipes.addShaped(<extracells:storage.gas:3>, [[<appliedenergistics2:tile.BlockQuartzGlass>, <appliedenergistics2:tile.BlockFluix>, <appliedenergistics2:tile.BlockQuartzGlass>],[<appliedenergistics2:tile.BlockFluix>, <extracells:storage.component:14>, <appliedenergistics2:tile.BlockFluix>],[<ore:ingotGold>, tank, <ore:ingotGold>]]);
-recipes.addShaped(<extracells:storage.gas:4>, [[<appliedenergistics2:tile.BlockQuartzGlass>, <appliedenergistics2:tile.BlockFluix>, <appliedenergistics2:tile.BlockQuartzGlass>],[<appliedenergistics2:tile.BlockFluix>, <extracells:storage.component:15>, <appliedenergistics2:tile.BlockFluix>],[<ore:ingotGold>, tank, <ore:ingotGold>]]);
-recipes.addShaped(<extracells:storage.gas:5>, [[<appliedenergistics2:tile.BlockQuartzGlass>, <appliedenergistics2:tile.BlockFluix>, <appliedenergistics2:tile.BlockQuartzGlass>],[<appliedenergistics2:tile.BlockFluix>, <extracells:storage.component:16>, <appliedenergistics2:tile.BlockFluix>],[<ore:ingotGold>, tank, <ore:ingotGold>]]);
-recipes.addShaped(<extracells:storage.gas:6>, [[<appliedenergistics2:tile.BlockQuartzGlass>, <appliedenergistics2:tile.BlockFluix>, <appliedenergistics2:tile.BlockQuartzGlass>],[<appliedenergistics2:tile.BlockFluix>, <extracells:storage.component:17>, <appliedenergistics2:tile.BlockFluix>],[<ore:ingotGold>, tank, <ore:ingotGold>]]);
+// Gating all gas storage cells behind the ChromatiCraft Crystal Tank Controller, and swap out fluix dust for fluix blocks
+// Again, these are commented out due to the lack of Mekanism
+//recipes.addShaped(<extracells:storage.gas>, [[<appliedenergistics2:tile.BlockQuartzGlass>, <appliedenergistics2:tile.BlockFluix>, <appliedenergistics2:tile.BlockQuartzGlass>],[<appliedenergistics2:tile.BlockFluix>, <extracells:storage.component:11>, <appliedenergistics2:tile.BlockFluix>],[<ore:ingotGold>, tank, <ore:ingotGold>]]);
+//recipes.addShaped(<extracells:storage.gas:1>, [[<appliedenergistics2:tile.BlockQuartzGlass>, <appliedenergistics2:tile.BlockFluix>, <appliedenergistics2:tile.BlockQuartzGlass>],[<appliedenergistics2:tile.BlockFluix>, <extracells:storage.component:12>, <appliedenergistics2:tile.BlockFluix>],[<ore:ingotGold>, tank, <ore:ingotGold>]]);
+//recipes.addShaped(<extracells:storage.gas:2>, [[<appliedenergistics2:tile.BlockQuartzGlass>, <appliedenergistics2:tile.BlockFluix>, <appliedenergistics2:tile.BlockQuartzGlass>],[<appliedenergistics2:tile.BlockFluix>, <extracells:storage.component:13>, <appliedenergistics2:tile.BlockFluix>],[<ore:ingotGold>, tank, <ore:ingotGold>]]);
+//recipes.addShaped(<extracells:storage.gas:3>, [[<appliedenergistics2:tile.BlockQuartzGlass>, <appliedenergistics2:tile.BlockFluix>, <appliedenergistics2:tile.BlockQuartzGlass>],[<appliedenergistics2:tile.BlockFluix>, <extracells:storage.component:14>, <appliedenergistics2:tile.BlockFluix>],[<ore:ingotGold>, tank, <ore:ingotGold>]]);
+//recipes.addShaped(<extracells:storage.gas:4>, [[<appliedenergistics2:tile.BlockQuartzGlass>, <appliedenergistics2:tile.BlockFluix>, <appliedenergistics2:tile.BlockQuartzGlass>],[<appliedenergistics2:tile.BlockFluix>, <extracells:storage.component:15>, <appliedenergistics2:tile.BlockFluix>],[<ore:ingotGold>, tank, <ore:ingotGold>]]);
+//recipes.addShaped(<extracells:storage.gas:5>, [[<appliedenergistics2:tile.BlockQuartzGlass>, <appliedenergistics2:tile.BlockFluix>, <appliedenergistics2:tile.BlockQuartzGlass>],[<appliedenergistics2:tile.BlockFluix>, <extracells:storage.component:16>, <appliedenergistics2:tile.BlockFluix>],[<ore:ingotGold>, tank, <ore:ingotGold>]]);
+//recipes.addShaped(<extracells:storage.gas:6>, [[<appliedenergistics2:tile.BlockQuartzGlass>, <appliedenergistics2:tile.BlockFluix>, <appliedenergistics2:tile.BlockQuartzGlass>],[<appliedenergistics2:tile.BlockFluix>, <extracells:storage.component:17>, <appliedenergistics2:tile.BlockFluix>],[<ore:ingotGold>, tank, <ore:ingotGold>]]);
 
-recipes.remove(<extracells:storage.casing:1>);
-recipes.remove(<extracells:storage.casing:2>);
-recipes.addShaped(<extracells:storage.casing:1>, [[<appliedenergistics2:tile.BlockQuartzGlass>, <appliedenergistics2:tile.BlockFluix>, <appliedenergistics2:tile.BlockQuartzGlass>],[<appliedenergistics2:tile.BlockFluix>, null, <appliedenergistics2:tile.BlockFluix>],[<extracells:certustank>, tank, <extracells:certustank>]]);
-recipes.addShaped(<extracells:storage.casing:2>, [[<appliedenergistics2:tile.BlockQuartzGlass>, <appliedenergistics2:tile.BlockFluix>, <appliedenergistics2:tile.BlockQuartzGlass>],[<appliedenergistics2:tile.BlockFluix>, null, <appliedenergistics2:tile.BlockFluix>],[<ore:ingotGold>, tank, <ore:ingotGold>]]);
-
+// Gate bedrockium drums behind the ChromatiCraft Crystal Tank Controller
 recipes.remove(<ExtraUtilities:drum:1>);
 recipes.addShaped(<ExtraUtilities:drum:1>, [[<ExtraUtilities:bedrockiumIngot>, <minecraft:light_weighted_pressure_plate>, <ExtraUtilities:bedrockiumIngot>], [<ExtraUtilities:bedrockiumIngot>, tank, <ExtraUtilities:bedrockiumIngot>], [<ExtraUtilities:bedrockiumIngot>, <minecraft:light_weighted_pressure_plate>, <ExtraUtilities:bedrockiumIngot>]]);

--- a/scripts/powertiers.zs
+++ b/scripts/powertiers.zs
@@ -1,48 +1,21 @@
-//ExU generators
-recipes.remove(<ExtraUtilities:generator:2>); //Lava
-recipes.addShaped(<ExtraUtilities:generator:2>, [[<ore:ingotInvar>, <ore:ingotInvar>, <ore:ingotInvar>], [<ore:ingotInvar>, <minecraft:gold_block>, <ore:ingotInvar>], [<minecraft:redstone>, <minecraft:furnace>, <minecraft:redstone>]]); //Lava
+// ExU generators
+// Gate the lava gen behind invar
+recipes.remove(<ExtraUtilities:generator:2>);
+recipes.addShaped(<ExtraUtilities:generator:2>, [[<ore:ingotInvar>, <ore:ingotInvar>, <ore:ingotInvar>], [<ore:ingotInvar>, <minecraft:gold_block>, <ore:ingotInvar>], [<minecraft:redstone>, <minecraft:furnace>, <minecraft:redstone>]]);
 
-recipes.remove(<ExtraUtilities:generator:3>);
-recipes.remove(<ExtraUtilities:generator:4>);
-recipes.remove(<ExtraUtilities:generator:5>);
-recipes.remove(<ExtraUtilities:generator:6>);
-recipes.remove(<ExtraUtilities:generator:7>);
-recipes.remove(<ExtraUtilities:generator:8>);
-recipes.remove(<ExtraUtilities:generator:9>);
-recipes.remove(<ExtraUtilities:generator:10>);
-recipes.remove(<ExtraUtilities:generator:11>);
-
-recipes.remove(<ExtraUtilities:nodeUpgrade:5>);
-recipes.remove(<ExtraUtilities:nodeUpgrade:6>);
-
-//Botania
-recipes.remove(<Botania:rfGenerator>);
-
-//BC pump HSLA gating
+// BC pump HSLA gating
 recipes.remove(<BuildCraft|Factory:pumpBlock>);
 recipes.addShaped(<BuildCraft|Factory:pumpBlock>, [[<BuildCraft|Factory:tankBlock>, <minecraft:bucket>, <BuildCraft|Factory:tankBlock>], [<ore:ingotIron>, <RotaryCraft:rotarycraft_item_enginecraft:0>, <ore:ingotIron>], [<ore:ingotIron>, <minecraft:redstone>, <ore:ingotIron>]]);
 
-//ExU power cable
-//recipes.remove(<ExtraUtilities:extractor_base:12>);
-//recipes.remove(<ExtraUtilities:extractor_base:13>);
+// ExU Energy Transfer Nodes
+recipes.remove(<ExtraUtilities:extractor_base:12>);
+recipes.remove(<ExtraUtilities:extractor_base:13>);
 
-recipes.remove(<EnderIO:blockZombieGenerator>);
-recipes.remove(<EnderIO:blockCombustionGenerator>);
-
-//recipes.remove(<ThermalExpansion:Machine:3>, [[null, <minecraft:bucket>, null], [<ore:ingotInvar>, <ore:thermalexpansion:machineFrame>, <ore:ingotInvar>], [<ore:gearInvar>, <ThermalExpansion:material:1>, <ore:gearInvar>]]);
-recipes.addShaped(<ThermalExpansion:Machine:3>.withTag({Augments: [{id: 5498 as short, Damage: 16 as short, Count: 1 as byte, Slot: 0}, {id: 5498 as short, Damage: 32 as short, Count: 1 as byte, Slot: 1}, {id: 5498 as short, Damage: 0 as short, Count: 1 as byte, Slot: 2}]}), [[null, <minecraft:bucket>, null], [<ore:ingotNickel>, <ThermalExpansion:Frame>, <ore:ingotNickel>], [<BuildCraft|Core:ironGearItem>, <ThermalExpansion:material:1>, <BuildCraft|Core:ironGearItem>]]);
-
-recipes.remove(<Forestry:engine:0>);
-recipes.remove(<Forestry:engine:1>);
-//recipes.remove(<Forestry:engine:2>);
-recipes.remove(<Forestry:engine:4>);
-//recipes.addShaped(<Forestry:engine:2>, [[<ore:ingotBronze>, <ore:ingotBronze>, <ore:ingotBronze>], [], []]);
-
-//Bronze
+// Disallow crafting to bronze. Must run it through a machine or TiC smeltery
 recipes.remove(<ore:ingotBronze>);
 recipes.remove(<ore:dustBronze>);
 
-//TiC Smeltery
+// Gate the TiCo lava tank behind Invar
 recipes.remove(<TConstruct:LavaTank>);
 recipes.addShaped(<TConstruct:LavaTank>, [[<TConstruct:materials:2>, <ore:ingotInvar>, <TConstruct:materials:2>], [<TConstruct:materials:2>, <ore:glass>, <TConstruct:materials:2>], [<TConstruct:materials:2>, <ore:ingotInvar>, <TConstruct:materials:2>]]);
 recipes.remove(<TConstruct:LavaTank:1>);
@@ -56,86 +29,57 @@ recipes.addShaped(<TConstruct:LavaTankNether:1>, [[<TConstruct:materials:37>, <o
 recipes.remove(<TConstruct:LavaTankNether:2>);
 recipes.addShaped(<TConstruct:LavaTankNether:2>, [[<TConstruct:materials:37>, <ore:glass>, <TConstruct:materials:37>], [<ore:ingotInvar>, <ore:glass>, <ore:ingotInvar>], [<TConstruct:materials:37>, <ore:glass>, <TConstruct:materials:37>]]);
 
+// Gate the TiCo Smetery behind Invar
 recipes.remove(<TConstruct:Smeltery>);
 recipes.addShaped(<TConstruct:Smeltery>, [[<TConstruct:materials:2>, <TConstruct:materials:2>, <TConstruct:materials:2>], [<TConstruct:materials:2>, <ore:ingotInvar>, <TConstruct:materials:2>], [<TConstruct:materials:2>, <TConstruct:materials:2>, <TConstruct:materials:2>]]);
 recipes.remove(<TConstruct:SmelteryNether>);
 recipes.addShaped(<TConstruct:SmelteryNether>, [[<TConstruct:materials:37>, <TConstruct:materials:37>, <TConstruct:materials:37>], [<TConstruct:materials:37>, <ore:ingotInvar>, <TConstruct:materials:37>], [<TConstruct:materials:37>, <TConstruct:materials:37>, <TConstruct:materials:37>]]);
 
+// Disallow crafting for these alloys. Must run them through a machine or TiC smeltery
 recipes.remove(<ore:dustInvar>);
 recipes.remove(<ore:dustElectrum>);
 recipes.remove(<ore:dustManyullyn>);
 recipes.remove(<ore:dustAluminumBrass>);
 
-//Pipe/Conduit Gating
+// Forces use of RotaryCraft Friction Heater to make EnderIO conduit bindings
 recipes.remove(<EnderIO:itemMaterial:2>);
-recipes.addShapeless(<EnderIO:itemMaterial:2>*8, [<minecraft:gravel>, <minecraft:gravel>, <minecraft:gravel>, <minecraft:gravel>, <minecraft:sand>, <minecraft:sand>, <minecraft:clay_ball>, <IC2:itemRubber>, <IC2:itemRubber>]);
+furnace.remove(<EnderIO:itemMaterial:2>);
+mods.thermalexpansion.Furnace.removeRecipe(<EnderIO:itemMaterial:2>);
 
-//recipes.remove(<IC2:itemRubber>);
-//furnace.remove(<IC2:itemRubber>);
-//mods.thermalexpansion.Furnace.removeRecipe(<IC2:itemRubber>);
-
-recipes.remove(<EnderIO:itemMaterial:1>);
-furnace.remove(<EnderIO:itemMaterial:1>);
-//mods.thermalexpansion.Furnace.removeRecipe(<EnderIO:itemMaterial:1>);
-
+// Thermal Dynamics Cryo-Stabilized Fluxduct
+// Gate behind RotaryCraft blast glass
 recipes.remove(<ThermalDynamics:ThermalDynamics_0:7>);
 recipes.addShaped(<ThermalDynamics:ThermalDynamics_0:7>, [[<ore:ingotElectrum>, <RotaryCraft:rotarycraft_block_blastglass>, <ore:ingotElectrum>], [<RotaryCraft:rotarycraft_block_blastglass>, <ThermalDynamics:ThermalDynamics_0:2>, <RotaryCraft:rotarycraft_block_blastglass>], [<ore:ingotElectrum>, <RotaryCraft:rotarycraft_block_blastglass>, <ore:ingotElectrum>]]);
 
-//recipes.remove(<ThermalDynamics:ThermalDynamics_0:0>);
-//recipes.remove(<ThermalDynamics:ThermalDynamics_0:1>);
-//recipes.remove(<ThermalDynamics:ThermalDynamics_0:2>);
-//recipes.remove(<ThermalDynamics:ThermalDynamics_0:3>);
-//recipes.remove(<ThermalDynamics:ThermalDynamics_0:4>);
-//recipes.remove(<ThermalDynamics:ThermalDynamics_0:5>);
-//recipes.remove(<ThermalDynamics:ThermalDynamics_0:6>);
-recipes.remove(<ThermalDynamics:ThermalDynamics_0:7>);
-
-//recipes.remove(<ThermalDynamics:ThermalDynamics_16:0>);
-//recipes.remove(<ThermalDynamics:ThermalDynamics_16:1>);
-//recipes.remove(<ThermalDynamics:ThermalDynamics_16:2>);
-//recipes.remove(<ThermalDynamics:ThermalDynamics_16:3>);
-//recipes.remove(<ThermalDynamics:ThermalDynamics_16:4>);
-//recipes.remove(<ThermalDynamics:ThermalDynamics_16:5>);
-//recipes.remove(<ThermalDynamics:ThermalDynamics_16:6>);
-//recipes.remove(<ThermalDynamics:ThermalDynamics_16:7>);
-
-//recipes.remove(<ThermalDynamics:ThermalDynamics_32:0>);
-//recipes.remove(<ThermalDynamics:ThermalDynamics_32:1>);
-//recipes.remove(<ThermalDynamics:ThermalDynamics_32:2>);
-//recipes.remove(<ThermalDynamics:ThermalDynamics_32:3>);
-//recipes.remove(<ThermalDynamics:ThermalDynamics_32:4>);
-//recipes.remove(<ThermalDynamics:ThermalDynamics_32:5>);
-//recipes.remove(<ThermalDynamics:ThermalDynamics_32:6>);
-//recipes.remove(<ThermalDynamics:ThermalDynamics_32:7>);
-
-recipes.remove(<ThermalExpansion:augment:64>);
-recipes.remove(<ThermalExpansion:augment:65>);
-recipes.remove(<ThermalExpansion:augment:66>);
-recipes.remove(<ThermalExpansion:augment:80>);
-recipes.remove(<ThermalExpansion:augment:81>);
-recipes.remove(<ThermalExpansion:augment:82>);
-
+// To be used for gating of Thermal Expansion augments
 var coil = <ThermalExpansion:material:2>;
 var redgold = <RotaryCraft:rotarycraft_item_compacts:6>;
 var tung = <RotaryCraft:rotarycraft_item_compacts:5>;
 
+// Thermal Expansion Fuel Efficiency Augments
+// Gate behind RotaryCraft
+recipes.remove(<ThermalExpansion:augment:64>);
+recipes.remove(<ThermalExpansion:augment:65>);
+recipes.remove(<ThermalExpansion:augment:66>);
 recipes.addShaped(<ThermalExpansion:augment:64>, [[null, <ore:ingotHSLA>, null], [<ore:ingotLead>, coil, <ore:ingotLead>], [<minecraft:redstone>, <ore:ingotHSLA>, <minecraft:redstone>]]);
 recipes.addShaped(<ThermalExpansion:augment:65>, [[null, redgold, null], [<ore:ingotLead>, coil, <ore:ingotLead>], [<minecraft:glowstone_dust>, redgold, <minecraft:glowstone_dust>]]);
 recipes.addShaped(<ThermalExpansion:augment:66>, [[null, redgold, null], [<ore:ingotElectrum>, coil, <ore:ingotElectrum>], [<ore:dustCryotheum>, redgold, <ore:dustCryotheum>]]);
 
+// Thermal Expansion Power Output Augments
+// Gate behind RotaryCraft
+recipes.remove(<ThermalExpansion:augment:80>);
+recipes.remove(<ThermalExpansion:augment:81>);
+recipes.remove(<ThermalExpansion:augment:82>);
 recipes.addShaped(<ThermalExpansion:augment:80>, [[null, redgold, null], [<ore:ingotSilver>, coil, <ore:ingotSilver>], [<minecraft:redstone>, redgold, <minecraft:redstone>]]);
 recipes.addShaped(<ThermalExpansion:augment:81>, [[null, tung, null], [<ore:ingotSilver>, coil, <ore:ingotSilver>], [<minecraft:glowstone_dust>, tung, <minecraft:glowstone_dust>]]);
 recipes.addShaped(<ThermalExpansion:augment:82>, [[null, tung, null], [<ore:ingotElectrum>, coil, <ore:ingotElectrum>], [<ore:dustCryotheum>, tung, <ore:dustCryotheum>]]);
 
-//recipes.remove(<RotaryCraft:rotarycraft_item_machine:45>);
-//The above line was commented out because the mod registering the item for which a recipe is being added or removed (RotaryCraft) has requested not to allow this. See your logs for more information, including on who to go to if you have further questions.
-//recipes.addShaped(<RotaryCraft:rotarycraft_item_machine:45>, [[<minecraft:stonebrick>, <Railcraft:ingot>, <minecraft:stonebrick>], [<ore:ingotInvar>, <minecraft:redstone>, <ore:ingotInvar>], [<minecraft:stonebrick>, <Railcraft:ingot>, <minecraft:stonebrick>]]);
-//The above line was commented out because the mod registering the item for which a recipe is being added or removed (RotaryCraft) has requested not to allow this. See your logs for more information, including on who to go to if you have further questions.
-
-recipes.remove(<EnderIO:blockCapBank:1>);
+// EnderIO Capacitor Bank Gating
+// Lowest tier is commented out because it relies on IC2 for gating. Perhaps switch it to ElectriCraft?
+//recipes.remove(<EnderIO:blockCapBank:1>);
 recipes.remove(<EnderIO:blockCapBank:2>);
 recipes.remove(<EnderIO:blockCapBank:3>);
 
-recipes.addShaped(<EnderIO:blockCapBank:1>, [[<ore:ingotIron>, <EnderIO:itemBasicCapacitor>, <ore:ingotIron>], [<EnderIO:itemBasicCapacitor>, <IC2:itemBatCrystal:26>, <EnderIO:itemBasicCapacitor>], [<ore:ingotIron>, <EnderIO:itemBasicCapacitor>, <ore:ingotIron>]]);
+//recipes.addShaped(<EnderIO:blockCapBank:1>, [[<ore:ingotIron>, <EnderIO:itemBasicCapacitor>, <ore:ingotIron>], [<EnderIO:itemBasicCapacitor>, <IC2:itemBatCrystal:26>, <EnderIO:itemBasicCapacitor>], [<ore:ingotIron>, <EnderIO:itemBasicCapacitor>, <ore:ingotIron>]]);
 recipes.addShaped(<EnderIO:blockCapBank:2>, [[<ore:ingotEnergeticAlloy>, <EnderIO:itemBasicCapacitor:1>, <ore:ingotEnergeticAlloy>], [<EnderIO:itemBasicCapacitor:1>, <EnderIO:blockCapBank:1>, <EnderIO:itemBasicCapacitor:1>], [<ore:ingotEnergeticAlloy>, <EnderIO:itemBasicCapacitor:1>, <ore:ingotEnergeticAlloy>]]);
 recipes.addShaped(<EnderIO:blockCapBank:3>, [[<ore:ingotPhasedGold>, <EnderIO:itemBasicCapacitor:2>, <ore:ingotPhasedGold>], [<EnderIO:itemBasicCapacitor:2>, <EnderIO:blockCapBank:2>, <EnderIO:itemBasicCapacitor:2>], [<ore:ingotPhasedGold>, <EnderIO:itemBasicCapacitor:2>, <ore:ingotPhasedGold>]]);

--- a/scripts/tweaks.zs
+++ b/scripts/tweaks.zs
@@ -157,9 +157,6 @@ recipes.addShaped(<Railcraft:part.gear:2>, [[null, <ore:ingotSteel>, null], [<or
 recipes.remove(<TwilightForest:item.emptyMagicMap>);
 recipes.addShaped(<TwilightForest:item.emptyMagicMap>, [[<minecraft:paper>, <TwilightForest:item.fieryBlood>, <minecraft:paper>], [<minecraft:paper>, <TwilightForest:item.tfFeather>, <minecraft:paper>], [<minecraft:paper>, <ChromatiCraft:chromaticraft_item_elemental:0>, <minecraft:paper>]]);
 
-recipes.remove(<ThermalExpansion:Device:2>);
-recipes.addShaped(<ThermalExpansion:Device:2>, [[<ChromatiCraft:chromaticraft_item_crafting:2>, <minecraft:chest>, <Thaumcraft:ItemGolemCore:8>], [<ore:gearDiamond>, <minecraft:piston>, <ore:gearDiamond>], [<RotaryCraft:rotarycraft_item_compacts:10>, <ThermalExpansion:material:1>, <BuildCraft|Silicon:redstoneChipset:2>]]);
-
 recipes.remove(<Mystcraft:writingdesk>);
 recipes.addShaped(<Mystcraft:writingdesk>, [[<minecraft:glass_bottle>, <ForbiddenMagic:Crystalwell>, <minecraft:feather>], [<ore:plankWood>, <ore:plankWood>, <ore:plankWood>], [<ore:plankWood>, null, <ore:plankWood>]]);
 recipes.remove(<Mystcraft:BlockBookBinder>);

--- a/scripts/tweaks.zs
+++ b/scripts/tweaks.zs
@@ -52,24 +52,6 @@ recipes.addShaped(<Botania:craftingHalo>, [[<ore:gemEmerald>, <ore:manaPearl>, <
 //recipes.remove(<extracells:storage.physical:2>);
 //recipes.remove(<extracells:storage.physical:3>);
 
-//recipes.remove(<RotaryCraft:rotarycraft_item_machine:109>);
-//The above line was commented out because the mod registering the item for which a recipe is being added or removed (RotaryCraft) has requested not to allow this. See your logs for more information, including on who to go to if you have further questions.
-//recipes.addShaped(<RotaryCraft:rotarycraft_item_machine:109>, [[<IC2:reactorCoolantSix:1>, <ThermalExpansion:material:1>, <ore:ingotLead>], [<ore:ingotSilver>, <ore:ingotCopper>, <ore:ingotSilver>], [<RotaryCraft:rotarycraft_item_shaftcraft>, <RotaryCraft:rotarycraft_item_enginecraft:16>, <RotaryCraft:rotarycraft_item_shaftcraft>]]);
-//The above line was commented out because the mod registering the item for which a recipe is being added or removed (RotaryCraft) has requested not to allow this. See your logs for more information, including on who to go to if you have further questions.
-
-recipes.remove(<JABBA:upgradeCore:0>);
-recipes.remove(<JABBA:upgradeCore:4>);
-recipes.remove(<JABBA:upgradeCore:5>);
-recipes.remove(<JABBA:upgradeCore:6>);
-recipes.remove(<JABBA:upgradeCore:8>);
-recipes.remove(<JABBA:upgradeCore:9>);
-
-recipes.remove(<StorageDrawers:upgrade:2>);
-recipes.remove(<StorageDrawers:upgrade:3>);
-recipes.remove(<StorageDrawers:upgrade:4>);
-recipes.remove(<StorageDrawers:upgrade:5>);
-recipes.remove(<StorageDrawers:upgrade:6>);
-
 recipes.remove(<StorageDrawers:tape>);
 recipes.addShaped(<StorageDrawers:tape>*3, [[null, <ore:slimeball>, null], [<minecraft:paper>, <minecraft:paper>, <minecraft:paper>]]);
 
@@ -263,9 +245,9 @@ recipes.remove(<Railcraft:machine.alpha:1>);
 recipes.addShaped(<Railcraft:machine.alpha:1>*4, [[<RotaryCraft:rotarycraft_item_shaftcraft>, <Railcraft:part.plate:1>, <RotaryCraft:rotarycraft_item_shaftcraft>], [<Railcraft:part.plate:1>, null, <Railcraft:part.plate:1>], [<RotaryCraft:rotarycraft_block_deco>, <Railcraft:part.plate:1>, <RotaryCraft:rotarycraft_block_deco>]]);
 
 //recipes.remove(<JABBA:upgradeCore:7>);
-recipes.addShaped(<JABBA:upgradeCore:7>, [[<minecraft:redstone>, <ore:plankWood>, <minecraft:redstone>], [<ore:stone>, <minecraft:redstone>, <ore:stone>], [<minecraft:redstone>, <ore:ingotIron>, <minecraft:redstone>]]);
+//recipes.addShaped(<JABBA:upgradeCore:7>, [[<minecraft:redstone>, <ore:plankWood>, <minecraft:redstone>], [<ore:stone>, <minecraft:redstone>, <ore:stone>], [<minecraft:redstone>, <ore:ingotIron>, <minecraft:redstone>]]);
 
-recipes.addShaped(<JABBA:upgradeStructural:1>, [[<minecraft:fence>, <ore:ingotTin>, <minecraft:fence>], [<ore:ingotTin>, null, <ore:ingotTin>], [<minecraft:fence>, <ore:ingotTin>, <minecraft:fence>]]);
+//recipes.addShaped(<JABBA:upgradeStructural:1>, [[<minecraft:fence>, <ore:ingotTin>, <minecraft:fence>], [<ore:ingotTin>, null, <ore:ingotTin>], [<minecraft:fence>, <ore:ingotTin>, <minecraft:fence>]]);
 
 recipes.remove(<gendustry:GeneticsProcessor>);
 recipes.remove(<gendustry:EnvProcessor>);

--- a/scripts/Ωfixes.zs
+++ b/scripts/Ωfixes.zs
@@ -1,7 +1,9 @@
+// Make charcoal from trees that don't have recipes for it -- vanilla furnace
 furnace.addRecipe(<minecraft:coal:1>, <Natura:Dark Tree:*>);
 furnace.addRecipe(<minecraft:coal:1>, <Natura:Rare Tree:*>);
 furnace.addRecipe(<minecraft:coal:1>, <TwilightForest:tile.TFMagicLog:*>);
 
+// Make charcoal from trees that don't have recipes for it -- Thermal Expansion furnace
 mods.thermalexpansion.Furnace.addRecipe(1600, <Natura:Dark Tree:*>, <minecraft:coal:1>);
 mods.thermalexpansion.Furnace.addRecipe(1600, <Natura:Rare Tree:*>, <minecraft:coal:1>);
 mods.thermalexpansion.Furnace.addRecipe(1600, <TwilightForest:tile.TFMagicLog:*>, <minecraft:coal:1>);


### PR DESCRIPTION
- Allows all generators again.
- Allows all TE augments for generators.
- Allows all JABBA and Storage Drawers upgrades.
- Un-gates some recipes where there were magic/tech interactions.
- Disables recipes designed to make things cheaper, but kept ones that made things more expensive or gated behind RotaryCraft or \* ChromatiCraft. In the case of CC, this includes even when CC gates tech items like the bedrockium drum or ExtraCells Fluid storage.
- Adds a lot of documentation where it is needed.
